### PR TITLE
Fix that 2 same alias can be generated in the xml

### DIFF
--- a/src/Model/Alias.yml
+++ b/src/Model/Alias.yml
@@ -1,16 +1,14 @@
 fields:
-    id: 'alias'
-    class: 'Alias'
-    columns:
-        alias:
-          type: word
-          args:
-            - 10
-        search:
-          type: word
-          args:
-            - 10
-        active:
-          type: boolean
-          args:
-            - 95 # probability of getting a true for this param
+  class: 'Alias'
+  columns:
+    alias:
+      type: word
+      unique: true
+    search:
+      type: text
+      args:
+        - 64
+    active:
+      type: boolean
+      args:
+        - 95 # probability of getting a true for this param


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | It was possible that 2 same alias are generated in the xml. It throw an error if the xml is used when install a PS
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #17 
| How to test?      | 
| Possible impacts? | Generate example data > Check in alias.xml if there is no duplicates aliases

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
