### PR TITLE
Fix error caused by 2 identical range weight can be generated for one carrier

### DIFF
--- a/src/Generator/EntityGenerator.php
+++ b/src/Generator/EntityGenerator.php
@@ -596,21 +596,22 @@ class EntityGenerator
             $value = call_user_func_array([$this, 'computeConditionalValue'], $argsFunctions);
         } elseif ($fakeType === 'increment') {
             $value = $this->increment++;
-        } elseif (array_key_exists('args', $fieldDescription)) {
-            $argsFunctions = $fieldDescription['args'];
-            $value = call_user_func_array([$fakerGenerator, $fakeType], $argsFunctions);
+        } else {
+            $argsFunctions = [];
+            if (array_key_exists('args', $fieldDescription)) {
+                $argsFunctions = $fieldDescription['args'];
+            }
+
+            if (array_key_exists('unique', $fieldDescription)) {
+                $value = call_user_func_array([$fakerGenerator->unique(), $fakeType], $argsFunctions);
+            } else {
+                $value = call_user_func_array([$fakerGenerator, $fakeType], $argsFunctions);
+            }
+
             if (is_array($value)) { // in case of words
                 $value = implode(' ', $value);
             }
-            if ($fakeType === 'boolean') {
-                $value = (int) $value;
-            }
-        } else {
-            if (array_key_exists('unique', $fieldDescription)) {
-                $value = $fakerGenerator->unique()->{$fakeType};
-            } else {
-                $value = $fakerGenerator->{$fakeType};
-            }
+
             if ($fakeType === 'boolean') {
                 $value = (int) $value;
             }

--- a/src/Model/RangeWeight.yml
+++ b/src/Model/RangeWeight.yml
@@ -9,6 +9,7 @@ fields:
           value: 0
         delimiter2:
           type: numberBetween
+          unique: true
           args:
-            - 1000
+            - 10
             - 10000


### PR DESCRIPTION
… carrier

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix error caused by 2 identical range weight can be generated for one carrier
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19 
| How to test?      | See #19 
| Possible impacts? |

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
